### PR TITLE
Remove unnecessary space on join

### DIFF
--- a/templates/hosts.j2
+++ b/templates/hosts.j2
@@ -3,6 +3,6 @@
 # Configuration file for dnsmasq
 
 {% for host in dnsmasq_conf_hosts -%}
-{{ host | join(' ') }}
+{{ host | join('') }}
 {% endfor %}
 


### PR DESCRIPTION
This causes funny entries in resulting hosts file (1 2 7 . 0 . 0 . 1 t e s t)
