### PR TITLE
Update main.yml  ansible_distribution value.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
      ansible_distribution != 'Ubuntu' and 
      ansible_distribution != 'CentOS' and 
      ansible_distribution != 'Debian' and 
-     ansible_distribution != 'Red Hat Enterprise Linux'
+     ansible_distribution != 'RedHat'
 
 - name: Include OS specific variables
   include_vars: "{{ ansible_os_family }}.yml"


### PR DESCRIPTION
Updated the value for "ansible_distribution" when executed against RHEL 7.3 using ansible 2.3.0.0.
        "ansible_distribution": "RedHat",

Looks like this rename has caused issues for other RHEL like distros and variations of the issue occur due to ansible version and RHEL version.  Not an easy thing to decide on how to fix.  Go with the future and forget the past?
For reference to similar issues:
https://github.com/ansible/ansible/issues/15671
https://github.com/dynaTrace/Dynatrace-Server-Ansible/issues/1