### PR TITLE
Update default variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # ansible-role-dnsmasq
 
-A versatile role to setup dnsmasq, created using this philosophy: 
+A versatile role to setup dnsmasq, created using this philosophy:
 https://github.com/jriguera/ansible-role-pattern/blob/master/README.md
 
-This role supports the definition of different interfaces for different 
+This role supports the definition of different interfaces for different
 purposes (dns, tftp ...) and a lot of dnsmasq parameters. Also it is
 able to manage the resolv.conf file.
 
@@ -23,7 +23,7 @@ dnsmasq_resolvconf: False
 dnsmasq_os_packages: True
 
 # Global parameters, settings needed! otherwise are ignored!
-dnsmasq_dhcp: True  
+dnsmasq_dhcp: True
 dnsmasq_tftp: True
 
 ### resolv.conf
@@ -54,7 +54,7 @@ dnsmasq_conf_bind_interfaces: 'dynamic'
 
 
 ### DNS
-# Accept DNS queries only from hosts whose address is on a local subnet,  
+# Accept DNS queries only from hosts whose address is on a local subnet,
 # ie a subnet for which an interface exists on the server.
 #dnsmasq_conf_local_service: True
 
@@ -63,7 +63,7 @@ dnsmasq_conf_domain_needed: True
 
 # Enable code to detect DNS forwarding loops; ie the situation where a query
 # sent to one of the upstream server eventually returns as a new query to the
-# dnsmasq instance.   
+# dnsmasq instance.
 #dnsmasq_conf_dns_loop_detect: True
 
 # All reverse lookups for private IP ranges (ie 192.168.x.x, etc) which
@@ -215,12 +215,12 @@ dnsmasq_conf_tftp_max: 50
 
 # Stop the TFTP server from negotiating the "blocksize" option with a client
 dnsmasq_conf_tftp_no_blocksize: False
-``` 
+```
 
-You can overwrite these default parameters as role variables. Have a look at 
+You can overwrite these default parameters as role variables. Have a look at
 the example in `site.yml` with vagrant and test it by using `vagrant up`.
 
-Apart of managing dnsmasq, this role is capable of managing `/etc/resolv.conf` 
+Apart of managing dnsmasq, this role is capable of managing `/etc/resolv.conf`
 file by defining `dnsmasq_resolvconf: true` and `dnsmasq_host_*` parameters.
 
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ dnsmasq_dhcp: True
 dnsmasq_tftp: True
 
 ### resolv.conf
-dnsmasq_host_domain: local
-dnsmasq_host_search: local
+#dnsmasq_host_domain: local
+#dnsmasq_host_search: local
 dnsmasq_host_resolvers: [ "127.0.0.1" ]
 
 # Set the facility to which dnsmasq will send syslog entries, this defaults to
@@ -41,7 +41,7 @@ dnsmasq_conf_log: /var/log/dnsmasq.log
 # Enable asynchronous logging and optionally set the limit on the number of
 # lines which will be queued by dnsmasq when writing to the syslog is slow.
 #dnsmasq_conf_log_async:
-dnsmasq_conf_log_dns: True
+dnsmasq_conf_log_dns: False
 
 # List of ip or interfaces to listen (empty list for all)
 dnsmasq_conf_listen: []

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,7 +52,7 @@ Vagrant.configure(2) do |config|
 #        sudo apt-get update
 #    SHELL
     master.vm.provision "ansible" do |ansible|
-	ansible.playbook = "site.yml"
+        ansible.playbook = "site.yml"
         #ansible.verbose = "vvv"
         #ansible.raw_arguments = "--list-task"
     end

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,16 +13,16 @@ dnsmasq_tftp: True
 ### resolv.conf
 #dnsmasq_host_domain: local
 #dnsmasq_host_search: local
-dnsmasq_host_resolvers: [ "127.0.0.1" ] 
+dnsmasq_host_resolvers: [ "127.0.0.1" ]
 
-# Set the facility to which dnsmasq will send syslog entries, this defaults to 
-# DAEMON, and to LOCAL0 when debug mode is in operation. If the facility given 
-# contains at least one '/' character, it is taken to be a filename, and dnsmasq 
-# logs to the given file, instead of syslog. If the facility is '-' then dnsmasq 
+# Set the facility to which dnsmasq will send syslog entries, this defaults to
+# DAEMON, and to LOCAL0 when debug mode is in operation. If the facility given
+# contains at least one '/' character, it is taken to be a filename, and dnsmasq
+# logs to the given file, instead of syslog. If the facility is '-' then dnsmasq
 # logs to stderr.
 dnsmasq_conf_log: /var/log/dnsmasq.log
 
-# Enable asynchronous logging and optionally set the limit on the number of 
+# Enable asynchronous logging and optionally set the limit on the number of
 # lines which will be queued by dnsmasq when writing to the syslog is slow.
 #dnsmasq_conf_log_async:
 dnsmasq_conf_log_dns: False
@@ -38,20 +38,20 @@ dnsmasq_conf_bind_interfaces: 'dynamic'
 
 
 ### DNS
-# Accept DNS queries only from hosts whose address is on a local subnet, 
-# ie a subnet for which an interface exists on the server. 
+# Accept DNS queries only from hosts whose address is on a local subnet,
+# ie a subnet for which an interface exists on the server.
 #dnsmasq_conf_local_service: True
 
 # Never forward plain names (without a dot or domain part)
 dnsmasq_conf_domain_needed: True
 
-# Enable code to detect DNS forwarding loops; ie the situation where a query 
-# sent to one of the upstream server eventually returns as a new query to the 
+# Enable code to detect DNS forwarding loops; ie the situation where a query
+# sent to one of the upstream server eventually returns as a new query to the
 # dnsmasq instance.
 #dnsmasq_conf_dns_loop_detect: True
 
-# All reverse lookups for private IP ranges (ie 192.168.x.x, etc) which 
-# are not found in /etc/hosts or the DHCP leases file are answered with 
+# All reverse lookups for private IP ranges (ie 192.168.x.x, etc) which
+# are not found in /etc/hosts or the DHCP leases file are answered with
 # "no such domain" rather than being forwarded upstream.
 # Never forward addresses in the non-routed address spaces.
 dnsmasq_conf_bogus_priv: True
@@ -66,20 +66,20 @@ dnsmasq_conf_hosts: []
 # Set the dns memory cachesize here.
 cache-size: 1024
 
-# Disable negative caching. Negative caching allows dnsmasq to remember 
-# "no such domain" answers from upstream nameservers and answer identical 
+# Disable negative caching. Negative caching allows dnsmasq to remember
+# "no such domain" answers from upstream nameservers and answer identical
 # queries without forwarding them again.
-# Negative replies from upstream servers normally contain time-to-live 
+# Negative replies from upstream servers normally contain time-to-live
 # information in SOA records which dnsmasq uses for caching. If this parameter
 # is undefined: "no-negcache".
 dnsmasq_conf_negcache: 5
 
-# This flag forces dnsmasq to try each query with each server strictly in 
+# This flag forces dnsmasq to try each query with each server strictly in
 # the order they appear in /etc/resolv.conf
 dnsmasq_conf_strict_order: False
 
-# This flag forces dnsmasq to send all queries to all available servers. 
-# The reply from the server which answers first will be returned to the 
+# This flag forces dnsmasq to send all queries to all available servers.
+# The reply from the server which answers first will be returned to the
 # original requester.
 dnsmasq_conf_all_servers: False
 
@@ -90,16 +90,16 @@ dnsmasq_conf_resolv: /etc/resolv.conf
 # Don't poll /etc/resolv.conf for changes.
 dnsmasq_conf_no_poll: False
 
-# if dnsmasq_conf_no_poll is False then /etc/resolv.conf is re-read or the 
+# if dnsmasq_conf_no_poll is False then /etc/resolv.conf is re-read or the
 # upstream servers are set via DBus, clear the DNS cache.
 dnsmasq_conf_clear_on_reload: True
 
-# Specify IP address of upstream servers directly. Setting this flag does not 
+# Specify IP address of upstream servers directly. Setting this flag does not
 # suppress reading of /etc/resolv.conf: ['localnet', '192.168.0.1']
-# Example of routing PTR queries to nameservers: this will send all: 
+# Example of routing PTR queries to nameservers: this will send all:
 # address->name queries for 192.168.3/24 to nameserver 10.1.2.3
 # ['3.168.192.in-addr.arpa', '10.1.2.3']
-#dnsmasq_conf_servers: 
+#dnsmasq_conf_servers:
 #  - [ "/google.com/", "8.8.8.8" ]
 #  - "8.8.4.4"
 dnsmasq_conf_servers: [ "8.8.8.8", "8.8.4.4" ]
@@ -113,7 +113,7 @@ dnsmasq_conf_servers: [ "8.8.8.8", "8.8.4.4" ]
 #dnsmasq_conf_mx_domain: {{ hostvars['k4.ww.mens.de'].
 #dnsmasq_conf_mx_pref: 1
 
-# Add A, AAAA and PTR records to the DNS. This adds one or more names to the 
+# Add A, AAAA and PTR records to the DNS. This adds one or more names to the
 # DNS with associated IPv4 (A) and IPv6 (AAAA) records
 #dnsmasq_conf_host_records:
 #  -[]
@@ -131,18 +131,18 @@ dnsmasq_conf_log_dhcp: False
 # 2) Sets the "domain" DHCP option thereby potentially setting the
 #    domain of all systems configured by DHCP
 # 3) Provides the domain part for "expand-hosts"
-# If the domain is given as "#" then the domain is read from the first 
+# If the domain is given as "#" then the domain is read from the first
 # "search" directive in /etc/resolv.conf
 dnsmasq_conf_domain: '#'
 
-# Only if dnsmasq_conf_domain is set, the unqualified name is no longer put 
+# Only if dnsmasq_conf_domain is set, the unqualified name is no longer put
 # in the DNS, only the qualified name.
 dnsmasq_conf_dhcp_fqdn: True
 
 # Should be set when dnsmasq is definitely the only DHCP server on a network.
 dnsmasq_conf_dhcp_authoritative: True
 
-# Dnsmasq is designed to choose IP addresses for DHCP clients using a hash 
+# Dnsmasq is designed to choose IP addresses for DHCP clients using a hash
 # of the client's MAC address.
 dnsmasq_conf_dhcp_sequential_ip: True
 
@@ -167,22 +167,22 @@ dnsmasq_conf_dhcp_no_override: True
 # Read DHCP host information from the list or from specified local file
 #dnsmasq_conf_dhcp_hosts: []
 
-# Completely suppress use of the lease database file. The file will not be 
+# Completely suppress use of the lease database file. The file will not be
 # created, read, or written.
 dnsmasq_conf_dhcp_leasefile_ro: False
 
-# Whenever a new DHCP lease is created, or an old one destroyed, or a TFTP file 
+# Whenever a new DHCP lease is created, or an old one destroyed, or a TFTP file
 # transfer completes, the executable specified by this option is run.
 #dnsmasq_conf_dhcp_script: files/program.bin
 
 
 ### TFTP
 
-# Enable TFTP secure mode: without this, any file which is readable by the 
+# Enable TFTP secure mode: without this, any file which is readable by the
 # dnsmasq process under normal unix access-control rules is available via TFTP
 dnsmasq_conf_tftp_secure: False
 
-# Convert filenames in TFTP requests to all lowercase. This is useful for 
+# Convert filenames in TFTP requests to all lowercase. This is useful for
 # requests from Windows machines
 dnsmasq_conf_tftp_lowercase: True
 
@@ -191,5 +191,3 @@ dnsmasq_conf_tftp_max: 50
 
 # Stop the TFTP server from negotiating the "blocksize" option with a client
 dnsmasq_conf_tftp_no_blocksize: False
-
-

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,8 +11,8 @@ dnsmasq_dhcp: True
 dnsmasq_tftp: True
 
 ### resolv.conf
-dnsmasq_host_domain: local 
-dnsmasq_host_search: local
+#dnsmasq_host_domain: local
+#dnsmasq_host_search: local
 dnsmasq_host_resolvers: [ "127.0.0.1" ] 
 
 # Set the facility to which dnsmasq will send syslog entries, this defaults to 
@@ -25,7 +25,7 @@ dnsmasq_conf_log: /var/log/dnsmasq.log
 # Enable asynchronous logging and optionally set the limit on the number of 
 # lines which will be queued by dnsmasq when writing to the syslog is slow.
 #dnsmasq_conf_log_async:
-dnsmasq_conf_log_dns: True
+dnsmasq_conf_log_dns: False
 
 # List of ip or interfaces to listen (empty list for all)
 dnsmasq_conf_listen: []

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,13 +1,12 @@
 ---
 - name: restart dnsmasq
   service: name="{{ dnsmasq_daemon }}" state=restarted
-  
+
 - name: reload dnsmasq
   shell: "kill -s HUP $(cat {{ dnsmasq_pidfile }})"
-  
+
 - name: start dnsmasq
   service: name="{{ dnsmasq_daemon }}" state=started
 
 - name: stop dnsmasq
   service: name="{{ dnsmasq_daemon }}" state=stopped
-

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,4 +21,3 @@ galaxy_info:
     - networking
 
 dependencies: []
-

--- a/site.yml
+++ b/site.yml
@@ -21,4 +21,3 @@
 
 #   - name: Display all variables/facts known for a host
 #     debug: var=hostvars[inventory_hostname]
-

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -131,4 +131,3 @@
     name: "{{ dnsmasq_daemon }}"
     state: started
     enabled: "{{ dnsmasq_enabled_on_startup | ternary('yes', 'no') }}"
-

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -18,7 +18,7 @@
     apt_repository: repo="{{ dnsmasq_os_repo_url }}" state=present
 
   when: >
-    ansible_os_family == 'Debian' 
+    ansible_os_family == 'Debian'
     and not dnsmasq_os_packages
   tags: ["debian", "repository"]
 
@@ -31,7 +31,7 @@
   - name: RedHat - Import repository key
     rpm_key: key="{{ dnsmasq_os_repo_key }}" state=present
     when: dnsmasq_os_repo_key is not none
-    
+
   when: >
     ansible_os_family == 'RedHat'
     and not dnsmasq_os_packages
@@ -49,7 +49,7 @@
   tags: ["redhat", "packages"]
 
 - name: Debian - Install required packages
-  apt: 
+  apt:
     name: "{{ item.key if ('version' not in item.value) else ('%s=%s' % (item.key, item.value['version'])) }}"
     state: "{{ item.value.state | default('present') }}"
     install_recommends: "{{ dnsmasq_packages_install_recommends }}"
@@ -99,5 +99,3 @@
 
   when: dnsmasq_init_system == 'systemd'
   tags: ["systemd", "init"]
-
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,9 +2,9 @@
 - name: Control if the role is supported on this system
   fail: msg="Dnsmasq role is not supported on this system"
   when: >
-     ansible_distribution != 'Ubuntu' and 
-     ansible_distribution != 'CentOS' and 
-     ansible_distribution != 'Debian' and 
+     ansible_distribution != 'Ubuntu' and
+     ansible_distribution != 'CentOS' and
+     ansible_distribution != 'Debian' and
      ansible_distribution != 'Red Hat Enterprise Linux'
 
 - name: Include OS specific variables
@@ -20,4 +20,3 @@
 
 - include: configure.yml
   tags: ["dnsmasq", "configure"]
-

--- a/tasks/resolvconf.yml
+++ b/tasks/resolvconf.yml
@@ -7,4 +7,3 @@
     group: root
     mode: 0644
   notify: reload dnsmasq
- 

--- a/templates/dnsmasq.conf.j2
+++ b/templates/dnsmasq.conf.j2
@@ -46,10 +46,10 @@ bind-interfaces
 {% endif %}
 
 {% if dnsmasq_conf_log is defined -%}
-# Set the facility to which dnsmasq will send syslog entries, this defaults to 
-# DAEMON, and to LOCAL0 when debug mode is in operation. If the facility given 
-# contains at least one '/' character, it is taken to be a filename, and dnsmasq 
-# logs to the given file, instead of syslog. If the facility is '-' then dnsmasq 
+# Set the facility to which dnsmasq will send syslog entries, this defaults to
+# DAEMON, and to LOCAL0 when debug mode is in operation. If the facility given
+# contains at least one '/' character, it is taken to be a filename, and dnsmasq
+# logs to the given file, instead of syslog. If the facility is '-' then dnsmasq
 # logs to stderr.
 {% if dnsmasq_conf_log is none -%}
 log-facility=DAEMON
@@ -59,7 +59,7 @@ log-facility={{ dnsmasq_conf_log }}
 {% endif %}
 
 {% if dnsmasq_conf_log_async is defined -%}
-# Enable asynchronous logging and optionally set the limit on the number of 
+# Enable asynchronous logging and optionally set the limit on the number of
 # lines which will be queued by dnsmasq when writing to the syslog is slow.
 {% if dnsmasq_conf_log_async is none %}
 log-async
@@ -83,15 +83,15 @@ domain-needed
 {% endif %}
 
 {% if dnsmasq_conf_dns_loop_detect is defined and dnsmasq_conf_dns_loop_detect -%}
-# Enable code to detect DNS forwarding loops; ie the situation where a query 
-# sent to one of the upstream server eventually returns as a new query to the 
-# dnsmasq instance. 
+# Enable code to detect DNS forwarding loops; ie the situation where a query
+# sent to one of the upstream server eventually returns as a new query to the
+# dnsmasq instance.
 dns-loop-detect
 {% endif %}
 
 {% if dnsmasq_conf_bogus_priv is defined and dnsmasq_conf_bogus_priv -%}
-# All reverse lookups for private IP ranges (ie 192.168.x.x, etc) which 
-# are not found in /etc/hosts or the DHCP leases file are answered with 
+# All reverse lookups for private IP ranges (ie 192.168.x.x, etc) which
+# are not found in /etc/hosts or the DHCP leases file are answered with
 # "no such domain" rather than being forwarded upstream.
 # Never forward addresses in the non-routed address spaces.
 bogus-priv
@@ -111,7 +111,7 @@ addn-hosts={{ dnsmasq_config_addhosts }}
 # Don't poll /etc/resolv.conf for changes.
 no-poll
 {% elif dnsmasq_conf_clear_on_reload is defined and dnsmasq_conf_clear_on_reload %}
-# If /etc/resolv.conf is re-read or the upstream servers are set via DBus, 
+# If /etc/resolv.conf is re-read or the upstream servers are set via DBus,
 # clear the DNS cache.
 clear-on-reload
 {% endif %}
@@ -121,26 +121,26 @@ cache-size={{ dnsmasq_conf_cache_size | default('1024') }}
 
 {% if dnsmasq_conf_negcache is defined -%}
 {% if not dnsmasq_conf_negcache is none -%}
-# Negative replies from upstream servers normally contain time-to-live 
+# Negative replies from upstream servers normally contain time-to-live
 # information in SOA records which dnsmasq uses for caching.
 neg-ttl={{ dnsmasq_conf_negcache }}
 {% else %}
-# Disable negative caching. Negative caching allows dnsmasq to remember 
-# "no such domain" answers from upstream nameservers and answer identical 
+# Disable negative caching. Negative caching allows dnsmasq to remember
+# "no such domain" answers from upstream nameservers and answer identical
 # queries without forwarding them again.
 no-negcache
 {% endif %}
 {% endif %}
 
 {% if dnsmasq_conf_strict_order is defined and dnsmasq_conf_strict_order -%}
-# This flag forces dnsmasq to try each query with each server strictly in 
+# This flag forces dnsmasq to try each query with each server strictly in
 # the order they appear in /etc/resolv.conf
 strict-order
 {% endif %}
 
 {% if dnsmasq_conf_all_servers is defined and dnsmasq_conf_all_servers -%}
-# This flag forces dnsmasq to send all queries to all available servers. 
-# The reply from the server which answers first will be returned to the 
+# This flag forces dnsmasq to send all queries to all available servers.
+# The reply from the server which answers first will be returned to the
 # original requester.
 all-servers
 {% endif %}
@@ -176,7 +176,7 @@ mx-target={{ dnsmasq_conf_mx }}
 {% endif %}
 
 {% if dnsmasq_conf_servers is defined and dnsmasq_conf_servers is iterable -%}
-# Specify IP address of upstream servers directly. Setting this flag does not 
+# Specify IP address of upstream servers directly. Setting this flag does not
 # suppress reading of /etc/resolv.conf.
 {% for server in dnsmasq_conf_servers -%}
 {% if server is string -%}
@@ -195,11 +195,9 @@ address={{ host | join(',') }}
 {% endif %}
 
 {% if dnsmasq_conf_host_records is defined and dnsmasq_conf_host_records is iterable -%}
-# Add A, AAAA and PTR records to the DNS. This adds one or more names to the 
+# Add A, AAAA and PTR records to the DNS. This adds one or more names to the
 # DNS with associated IPv4 (A) and IPv6 (AAAA) records
 {% for host in dnsmasq_conf_host_records -%}
 host-record={{ host | join(',') }}
 {% endfor %}
 {% endif %}
-
-

--- a/templates/dnsmasq.d/dhcp.conf.j2
+++ b/templates/dnsmasq.d/dhcp.conf.j2
@@ -16,7 +16,7 @@ log-dhcp
 # 2) Sets the "domain" DHCP option thereby potentially setting the
 #    domain of all systems configured by DHCP
 # 3) Provides the domain part for "expand-hosts"
-# If the domain is given as "#" then the domain is read from the first 
+# If the domain is given as "#" then the domain is read from the first
 # "search" directive in /etc/resolv.conf
 domain={{ dnsmasq_conf_domain }}
 
@@ -32,7 +32,7 @@ dhcp-authoritative
 {% endif %}
 
 {% if dnsmasq_conf_dhcp_sequential_ip is defined and dnsmasq_conf_dhcp_sequential_ip -%}
-# Dnsmasq is designed to choose IP addresses for DHCP clients using a hash 
+# Dnsmasq is designed to choose IP addresses for DHCP clients using a hash
 # of the client's MAC address.
 dhcp-sequential-ip
 {% endif %}
@@ -42,8 +42,8 @@ dhcp-sequential-ip
 dhcp-no-override
 {% endif %}
 
-# Integrated DHCP server, you need to supply the range of addresses available 
-# for lease and optionally a lease time. If you have more than one network, 
+# Integrated DHCP server, you need to supply the range of addresses available
+# for lease and optionally a lease time. If you have more than one network,
 # you will need to repeat this for each network on which you want to supply DHCP
 # service.
 {% for values in dnsmasq_conf_dhcp -%}
@@ -53,11 +53,11 @@ dhcp-range=set:{{ key }},{{ values["range"] | join(',') }}
 {% if values["option"] is defined -%}
 # Send options to hosts which ask for a DHCP lease.
 # See RFC 2132 for details of available options.
-# Common options can be given to dnsmasq by name: 
+# Common options can be given to dnsmasq by name:
 # run "dnsmasq --help dhcp" to get a list.
 # Note that all the common settings, such as netmask and
 # broadcast address, DNS server and default route, are given
-# sane defaults by dnsmasq. You very likely will not need 
+# sane defaults by dnsmasq. You very likely will not need
 # any dhcp-options. If you use Windows clients and Samba, there
 # are some options which are recommended, they are detailed at the
 # end of this section.
@@ -73,9 +73,9 @@ dhcp-option=tag:{{ key }},{{ match }}
 {% endif %}
 
 {% if values["boot"] is defined -%}
-# (IPv4 only) Set BOOTP options to be returned by the DHCP server. Server name 
-# and address are optional: if not provided, the name is left empty, and the 
-# address set to the address of the machine running dnsmasq. 
+# (IPv4 only) Set BOOTP options to be returned by the DHCP server. Server name
+# and address are optional: if not provided, the name is left empty, and the
+# address set to the address of the machine running dnsmasq.
 {% for boot in values["boot"] -%}
 dhcp-boot=tag:{{ key }},{{ boot }}
 {% endfor %}
@@ -87,41 +87,40 @@ pxe-service=tag:{{ key }},{{ pservice }}
 {% endfor %}
 {% endif %}
 
-{% if values["pxe_prompt"] is defined -%} 
+{% if values["pxe_prompt"] is defined -%}
 {% for pprompt in values["pxe_prompt"] -%}
 pxe-prompt=tag:{{ key }},{{ pprompt  }}
 {% endfor %}
 {% endif %}
 
 {% if values["ignore_names"] is defined and values["ignore_names"] -%}
-# When all the given tags appear in the tag set, ignore any hostname provided 
-# by the host. 
+# When all the given tags appear in the tag set, ignore any hostname provided
+# by the host.
 dhcp-ignore-names=tag:{{ key }}
 {% endif %}
 
 {% if values["generate_names"] is defined and values["generate_names"] -%}
-# (IPv4 only) Generate a name for DHCP clients which do not otherwise have one, 
-# using the MAC address expressed in hex, separated by dashes. 
+# (IPv4 only) Generate a name for DHCP clients which do not otherwise have one,
+# using the MAC address expressed in hex, separated by dashes.
 dhcp-generate-names=tag:{{ key }}
 {% endif %}
 {% endfor %}
 
 {% if dnsmasq_conf_dhcp_hostsfile is defined and not dnsmasq_conf_dhcp_hostsfile is none -%}
-# Read DHCP host information from the specified file. If a directory is given, 
-# then read all the files contained in that directory. The file contains 
+# Read DHCP host information from the specified file. If a directory is given,
+# then read all the files contained in that directory. The file contains
 # information about one host per line
 dhcp-hostsfile={{ dnsmasq_config_dhcphosts }}
 {% endif %}
 
 {% if dnsmasq_conf_dhcp_leasefile_ro is defined and dnsmasq_conf_dhcp_leasefile_ro -%}
-# Completely suppress use of the lease database file. The file will not be 
+# Completely suppress use of the lease database file. The file will not be
 # created, read, or written.
 leasefile-ro
 {% endif %}
 
 {% if dnsmasq_conf_dhcp_script is defined and not dnsmasq_conf_dhcp_script is none -%}
-# Whenever a new DHCP lease is created, or an old one destroyed, or a TFTP file 
+# Whenever a new DHCP lease is created, or an old one destroyed, or a TFTP file
 # transfer completes, the executable specified by this option is run.
 dhcp-script={{ dnsmasq_config_dhcpscript }}
 {% endif %}
-

--- a/templates/dnsmasq.d/tftp.conf.j2
+++ b/templates/dnsmasq.d/tftp.conf.j2
@@ -18,13 +18,13 @@ tftp-root={{ values["tftp"] }},{{ key }}
 
 
 {% if dnsmasq_conf_tftp_secure is defined and dnsmasq_conf_tftp_secure -%}
-# Enable TFTP secure mode: without this, any file which is readable by the 
+# Enable TFTP secure mode: without this, any file which is readable by the
 # dnsmasq process under normal unix access-control rules is available via TFTP
 tftp-secure
 {% endif %}
 
 {% if dnsmasq_conf_tftp_lowercase is defined and dnsmasq_conf_tftp_lowercase -%}
-# Convert filenames in TFTP requests to all lowercase. This is useful for 
+# Convert filenames in TFTP requests to all lowercase. This is useful for
 # requests from Windows machines
 tftp-lowercase
 {% endif %}
@@ -33,7 +33,6 @@ tftp-lowercase
 tftp-max={{ dnsmasq_conf_tftp_max | default('50') }}
 
 {% if dnsmasq_conf_tftp_no_blocksize is defined and dnsmasq_conf_tftp_no_blocksize -%}
-# Stop the TFTP server from negotiating the "blocksize" option with a client. 
+# Stop the TFTP server from negotiating the "blocksize" option with a client.
 tftp-no-blocksize
 {% endif %}
-

--- a/templates/hosts.j2
+++ b/templates/hosts.j2
@@ -5,4 +5,3 @@
 {% for host in dnsmasq_conf_hosts -%}
 {{ host | join(' ') }}
 {% endfor %}
-

--- a/templates/resolv.conf.j2
+++ b/templates/resolv.conf.j2
@@ -1,10 +1,10 @@
 #jinja2: trim_blocks: "true", lstrip_blocks: "true"
 # {{ ansible_managed }}
 
-{% if dnsmasq_host_domain is defined -%}
+{% if dnsmasq_host_domain is defined and dnsmasq_host_domain -%}
 domain {{ dnsmasq_host_domain }}
 {% endif -%}
-{% if dnsmasq_host_search is defined -%}
+{% if dnsmasq_host_search is defined and dnsmasq_host_search -%}
 search {{ dnsmasq_host_search }}
 {% endif -%}
 {% for ns in dnsmasq_host_resolvers -%}

--- a/templates/resolv.conf.j2
+++ b/templates/resolv.conf.j2
@@ -10,4 +10,3 @@ search {{ dnsmasq_host_search }}
 {% for ns in dnsmasq_host_resolvers -%}
 nameserver {{ ns }}
 {% endfor %}
-

--- a/templates/systemd.conf.j2
+++ b/templates/systemd.conf.j2
@@ -1,4 +1,3 @@
 [Service]
 ExecStartPost=/bin/sh -c 'sleep 1 && pgrep -u {{ dnsmasq_user }} dnsmasq > {{ dnsmasq_pidfile }}'
 ExecStopPost=/bin/rm -f {{ dnsmasq_pidfile }}
-

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,4 +4,3 @@ dnsmasq_pidfile: /var/run/dnsmasq/dnsmasq.pid
 dnsmasq_packages:
   dnsmasq:
     state: latest
-

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -17,4 +17,3 @@ dnsmasq_var_dir: /var/lib/dnsmasq
 dnsmasq_config_addhosts: /etc/dnsmasq.hosts
 dnsmasq_config_dhcphosts: /var/lib/dnsmasq/dhcp.leases
 dnsmasq_config_dhcpscript: /var/lib/dnsmasq/script
-


### PR DESCRIPTION
Make it possible to not set `dnsmasq_host_domain`, `dnsmasq_host_search`, `dnsmasq_conf_log_dns`. 