### PR TITLE
Handlers require become: if remote_user is not root

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,12 +1,20 @@
 ---
 - name: restart dnsmasq
   service: name="{{ dnsmasq_daemon }}" state=restarted
+  become: true
+  become_user: root
 
 - name: reload dnsmasq
   shell: "kill -s HUP $(cat {{ dnsmasq_pidfile }})"
+  become: true
+  become_user: nobody
 
 - name: start dnsmasq
   service: name="{{ dnsmasq_daemon }}" state=started
+  become: true
+  become_user: root
 
 - name: stop dnsmasq
   service: name="{{ dnsmasq_daemon }}" state=stopped
+  become: true
+  become_user: root


### PR DESCRIPTION
When Ansibles remote_user is not root the handlers would run under the id of remote_user, which will lead to a permission denied error when running the reload handler.

I ran into this problem when using this role with a CentOS cloud image in OpenStack, where the normal way is to connect as "centos" and then to become root. The handler would then be executed as "centos", and so the reload "kill" failed because it needed to be either "root" or "nobody".

To be honest, I have no idea how these changes affect Ubuntu installations. Should work if dnsmasq runs as nobody in Ubuntu.